### PR TITLE
Exposed parameter for min step size in NumericDiffOptions

### DIFF
--- a/include/ceres/internal/numeric_diff.h
+++ b/include/ceres/internal/numeric_diff.h
@@ -142,7 +142,7 @@ struct NumericDiff {
     // small. This will lead to problems with round off and numerical
     // instability when dividing by the step size. The general
     // recommendation is to not go down below sqrt(epsilon).
-    double min_step_size = std::sqrt(std::numeric_limits<double>::epsilon());
+    double min_step_size = options.min_step_size;
 
     // For Ridders' method, the initial step size is required to be large,
     // thus ridders_relative_initial_step_size is used.

--- a/include/ceres/numeric_diff_options.h
+++ b/include/ceres/numeric_diff_options.h
@@ -39,6 +39,7 @@ namespace ceres {
 struct CERES_EXPORT NumericDiffOptions {
   NumericDiffOptions() {
     relative_step_size = 1e-6;
+    min_step_size = std::sqrt(std::numeric_limits<double>::epsilon());
     ridders_relative_initial_step_size = 1e-2;
     max_num_ridders_extrapolations = 10;
     ridders_epsilon = 1e-12;
@@ -47,8 +48,15 @@ struct CERES_EXPORT NumericDiffOptions {
 
   // Numeric differentiation step size (multiplied by parameter block's
   // order of magnitude). If parameters are close to zero, the step size
-  // is set to sqrt(machine_epsilon).
+  // is set to min_step_size.
   double relative_step_size;
+
+  // The minimum numeric differentiation step size. It is not a
+  // good idea to make the step size arbitrarily small.
+  // This will lead to problems with round off and numerical
+  // instability when dividing by the step size. The general
+  // recommendation is to not go down below sqrt(epsilon).
+  double min_step_size;
 
   // Initial step size for Ridders adaptive numeric differentiation (multiplied
   // by parameter block's order of magnitude).


### PR DESCRIPTION
The proposed change allows to change the minimum step size used for numeric differentiation in case one runs into numerical instabilities with the default value.