### PR TITLE
Fixed a bug of sqrt(Jet<T>) in jet.h. When the input value f is 0, th…

### DIFF
--- a/include/ceres/jet.h
+++ b/include/ceres/jet.h
@@ -495,7 +495,7 @@ Jet<T, N> exp(const Jet<T, N>& f) {
 template <typename T, int N> inline
 Jet<T, N> sqrt(const Jet<T, N>& f) {
   const T tmp = sqrt(f.a);
-  const T two_a_inverse = T(1.0) / (T(2.0) * tmp);
+  const T two_a_inverse = T(1.0) /T(2.0) * tmp;
   return Jet<T, N>(tmp, f.v * two_a_inverse);
 }
 


### PR DESCRIPTION
Fixed a bug of sqrt(Jet<T>) in jet.h. When the input value f is 0, the f.v will be divided by zero and get NaN. It's fixed if change the two_a_inverse = 1/(2*tmp) --> two_a_inverse= 1/2*tmp.