### PR TITLE
Implement move semantics for AutoDiff

### DIFF
--- a/include/ceres/autodiff_cost_function.h
+++ b/include/ceres/autodiff_cost_function.h
@@ -152,29 +152,52 @@ template <typename CostFunctor,
           int... Ns>          // Number of parameters in each parameter block.
 class AutoDiffCostFunction : public SizedCostFunction<kNumResiduals, Ns...> {
  public:
-  // Takes ownership of functor. Uses the template-provided value for the
-  // number of residuals ("kNumResiduals").
-  explicit AutoDiffCostFunction(CostFunctor* functor)
-      : functor_(functor) {
+  // Takes ownership of functor by default, but optional. Uses the
+  // template-provided value for the number of residuals ("kNumResiduals").
+  explicit AutoDiffCostFunction(CostFunctor* functor,
+                                Ownership ownership = TAKE_OWNERSHIP)
+      : functor_(functor), functorOwnership_(ownership) {
     static_assert(kNumResiduals != DYNAMIC,
                   "Can't run the fixed-size constructor if the number of "
                   "residuals is set to ceres::DYNAMIC.");
   }
 
-  // Takes ownership of functor. Ignores the template-provided
-  // kNumResiduals in favor of the "num_residuals" argument provided.
+  // Takes ownership of functor by default, but optional. Ignores the
+  // template-provided kNumResiduals in favor of the "num_residuals" argument
+  // provided.
   //
   // This allows for having autodiff cost functions which return varying
   // numbers of residuals at runtime.
-  AutoDiffCostFunction(CostFunctor* functor, int num_residuals)
-      : functor_(functor) {
+  explicit AutoDiffCostFunction(CostFunctor* functor,
+                                int num_residuals,
+                                Ownership ownership = TAKE_OWNERSHIP)
+      : functor_(functor), functorOwnership_(ownership) {
     static_assert(kNumResiduals == DYNAMIC,
                   "Can't run the dynamic-size constructor if the number of "
                   "residuals is not ceres::DYNAMIC.");
     SizedCostFunction<kNumResiduals, Ns...>::set_num_residuals(num_residuals);
   }
 
-  virtual ~AutoDiffCostFunction() {}
+  // Move constructor
+  AutoDiffCostFunction(AutoDiffCostFunction&& other) noexcept
+      : functor_(std::move(other.functor_)),
+        functorOwnership_(std::move(other.functorOwnership_)) {
+    other.functorOwnership_ = DO_NOT_TAKE_OWNERSHIP;
+  }
+
+  // Move assignment
+  AutoDiffCostFunction& operator=(AutoDiffCostFunction&& other) noexcept {
+    functor_ = std::move(other.functor_);
+    functorOwnership_ = std::move(other.functorOwnership_);
+    other.functorOwnership_ = DO_NOT_TAKE_OWNERSHIP;
+    return *this;
+  }
+
+  virtual ~AutoDiffCostFunction() {
+    if (functorOwnership_ == DO_NOT_TAKE_OWNERSHIP) {
+      functor_.release();
+    }
+  }
 
   // Implementation details follow; clients of the autodiff cost function should
   // not have to examine below here.
@@ -188,9 +211,8 @@ class AutoDiffCostFunction : public SizedCostFunction<kNumResiduals, Ns...> {
         typename SizedCostFunction<kNumResiduals, Ns...>::ParameterDims;
 
     if (!jacobians) {
-      return internal::VariadicEvaluate<ParameterDims>(*functor_,
-                                                       parameters,
-                                                       residuals);
+      return internal::VariadicEvaluate<ParameterDims>(
+          *functor_, parameters, residuals);
     }
     return internal::AutoDifferentiate<ParameterDims>(
         *functor_,
@@ -202,6 +224,7 @@ class AutoDiffCostFunction : public SizedCostFunction<kNumResiduals, Ns...> {
 
  private:
   std::unique_ptr<CostFunctor> functor_;
+  Ownership functorOwnership_;
 };
 
 }  // namespace ceres


### PR DESCRIPTION
This allows us to pre-allocate memory for the cost functions.