### PR TITLE
Protect declarations of lapack functions under CERES_NO_LAPACK

### DIFF
--- a/internal/ceres/lapack.cc
+++ b/internal/ceres/lapack.cc
@@ -34,6 +34,7 @@
 #include "ceres/linear_solver.h"
 #include "glog/logging.h"
 
+#ifndef CERES_NO_LAPACK
 // C interface to the LAPACK Cholesky factorization and triangular solve.
 extern "C" void dpotrf_(char* uplo,
                        int* n,
@@ -61,7 +62,7 @@ extern "C" void dgels_(char* uplo,
                        double* work,
                        int* lwork,
                        int* info);
-
+#endif
 
 namespace ceres {
 namespace internal {


### PR DESCRIPTION
If lapack functions are provided by someone else these declarations may
conflict. For example linking with a version of Eigen that links to MKL
conflicted with MKL's declaration of these functions.

The rest of the file is already using CERES_NO_LAPACK to disable the implementation so I just extended the usage here.