### PR TITLE
Fix target include directories

### DIFF
--- a/internal/ceres/CMakeLists.txt
+++ b/internal/ceres/CMakeLists.txt
@@ -291,7 +291,8 @@ target_include_directories(ceres PUBLIC
 # warnings around the #include statments for Eigen headers across all GCC/Clang
 # versions, we tell CMake to treat Eigen headers as system headers.  This
 # results in all compiler warnings from them being suppressed.
-target_include_directories(ceres SYSTEM PUBLIC ${EIGEN_INCLUDE_DIRS})
+target_include_directories(ceres SYSTEM PUBLIC
+  $<BUILD_INTERFACE:${EIGEN_INCLUDE_DIRS}>)
 
 # Gather the list of public & private include locations for all enabled optional
 # dependencies to be added to the Ceres target.


### PR DESCRIPTION
Should fix #451 

If EIGEN_INCLUDE_DIR is provided e.g. from FetchContent as $depends-eigen-source-dir, and I try to build a library using `target_link_directories(libcore INTERFACE ceres)`, then an error occurs that the INTERFACE_INCLDUE_DIRECTORIES contains path which is prefixed,.

This commit should fix this issue.

Change-Id: Ib1c014d428fe3808664634de4596b2fcf484a518