### PR TITLE
Fix Solver::Options::gradient_check_relative_precision documentation typo

### DIFF
--- a/docs/source/nnls_solving.rst
+++ b/docs/source/nnls_solving.rst
@@ -1571,7 +1571,7 @@ elimination group [LiSaad]_.
 
 .. member:: double Solver::Options::gradient_check_relative_precision
 
-   Default: ``1e08``
+   Default: ``1e-8``
 
    Precision to check for in the gradient checker. If the relative
    difference between an element in a Jacobian exceeds this number,


### PR DESCRIPTION
In the docs, `Solver::Options::gradient_check_relative_precision` is
documented to have a default precision of 1e08. That is incorrect, it
should be 1e-8.

![Screenshot_2019-10-18_12-18-11](https://user-images.githubusercontent.com/91460/67090631-87643c80-f1a2-11e9-87cc-729b8c008943.png)

The `solver.h` header confirms my PR: https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/solver.h#L687
