### PR TITLE
fixed array: dont use depr member types of std allocator

### DIFF
--- a/include/ceres/internal/fixed_array.h
+++ b/include/ceres/internal/fixed_array.h
@@ -106,10 +106,10 @@ class FixedArray {
  public:
   using allocator_type = typename AllocatorTraits::allocator_type;
   using value_type = typename allocator_type::value_type;
-  using pointer = typename allocator_type::pointer;
-  using const_pointer = typename allocator_type::const_pointer;
-  using reference = typename allocator_type::reference;
-  using const_reference = typename allocator_type::const_reference;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
   using size_type = typename allocator_type::size_type;
   using difference_type = typename allocator_type::difference_type;
   using iterator = pointer;


### PR DESCRIPTION
C++17 deprecates the pointer, const_pointer, reference and const_reference member types in std::allocator. In c++20 they are removed. In particular this change is necessary to able to compile ceres with gcc 10 with -std=c++20.