### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -488,9 +488,6 @@ Notes:
    port their build system to something sane like ``CMake``, and get a
    fully supported Windows port.
 
-
-.. _section-android:
-
 Installation using vcpkg
 ========================
 You can download and install Ceres using the `vcpkg <https://github.com/Microsoft/vcpkg/>`_ dependency manager:
@@ -503,6 +500,8 @@ You can download and install Ceres using the `vcpkg <https://github.com/Microsof
     ./vcpkg install ceres
 
 The Ceres port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
+
+.. _section-android:
 
 Android
 =======

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -491,19 +491,18 @@ Notes:
 
 .. _section-android:
 
-Building ceres - Using vcpkg
-============================
+Installation using vcpkg
+========================
+You can download and install Ceres using the `vcpkg <https://github.com/Microsoft/vcpkg/>`_ dependency manager:
 
-The url of vcpkg is: https://github.com/Microsoft/vcpkg
-You can download and install ceres using the vcpkg dependency manager:
-
+.. code-block:: bash
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
     ./vcpkg install ceres
 
-The ceres port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository.
+The Ceres port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
 
 Android
 =======

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -491,6 +491,20 @@ Notes:
 
 .. _section-android:
 
+Building ceres - Using vcpkg
+============================
+
+The url of vcpkg is: https://github.com/Microsoft/vcpkg
+You can download and install ceres using the vcpkg dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install ceres
+
+The ceres port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository.
+
 Android
 =======
 


### PR DESCRIPTION
Ceres is available as a port in vcpkg, a C++ library manager that simplifies installation for ceres and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build ceres, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.