### PR TITLE
SubsetParameterization: allow empty set of constant parameters

### DIFF
--- a/internal/ceres/local_parameterization.cc
+++ b/internal/ceres/local_parameterization.cc
@@ -94,6 +94,9 @@ bool IdentityParameterization::MultiplyByJacobian(const double* x,
 SubsetParameterization::SubsetParameterization(
     int size, const vector<int>& constant_parameters)
     : local_size_(size - constant_parameters.size()), constancy_mask_(size, 0) {
+  if (constant_parameters.empty()) {
+    return;
+  }
   vector<int> constant = constant_parameters;
   std::sort(constant.begin(), constant.end());
   CHECK_GE(constant.front(), 0) << "Indices indicating constant parameter must "


### PR DESCRIPTION
SubsetParameterization should work nicely even if the set is the full set, i.e. there are no constant parameters.
In fact, everything works fine, except the checks in the constructor.
This exits the constructor early if the set is empty, so that the checks don't crash ceres.

Note: according to this comment by @emilk, it worked a while ago:
https://github.com/ceres-solver/ceres-solver/issues/347#issuecomment-368302331