### PR TITLE
Use GNUInstallDirs for install locations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ list(APPEND CMAKE_MODULE_PATH "${Ceres_SOURCE_DIR}/cmake")
 include(AddCompileFlagsIfSupported)
 include(UpdateCacheVariable)
 
+# Use standard installation directories.
+include(GNUInstallDirs)
+
 # Xcode 11.0-1 with macOS 10.15 (Catalina) broke alignment.
 include(DetectBrokenStackCheckMacOSXcodePairing)
 detect_broken_stack_check_macos_xcode_pairing()
@@ -720,7 +723,7 @@ write_basic_package_version_file("${Ceres_BINARY_DIR}/CeresConfigVersion.cmake"
 if (WIN32)
   set(RELATIVE_CMAKECONFIG_INSTALL_DIR CMake)
 else ()
-  set(RELATIVE_CMAKECONFIG_INSTALL_DIR lib${LIB_SUFFIX}/cmake/Ceres)
+  set(RELATIVE_CMAKECONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/Ceres)
 endif ()
 
 # This "exports" for installation all targets which have been put into the

--- a/internal/ceres/CMakeLists.txt
+++ b/internal/ceres/CMakeLists.txt
@@ -315,7 +315,7 @@ target_include_directories(ceres BEFORE PUBLIC
 target_include_directories(ceres PRIVATE ${Ceres_SOURCE_DIR}/internal)
 target_include_directories(ceres PUBLIC
   $<BUILD_INTERFACE:${Ceres_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Eigen SparseQR generates various compiler warnings related to unused and
 # uninitialised local variables.  To avoid having to individually suppress these
@@ -373,9 +373,9 @@ endforeach()
 
 install(TARGETS ceres
         EXPORT  CeresExport
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIB_SUFFIX}
-        ARCHIVE DESTINATION lib${LIB_SUFFIX})
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Create a local alias target that matches the expected installed target.
 add_library(Ceres::ceres ALIAS ceres)


### PR DESCRIPTION
This change should be a no-op for all FHS systems given the default values of the variables:

https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

But it's required to be able to properly package Ceres with split outputs under NixOS.