### PR TITLE
Remove the deleted file from CERES_SRCS

### DIFF
--- a/bazel/ceres.bzl
+++ b/bazel/ceres.bzl
@@ -116,7 +116,6 @@ CERES_SRCS = ["internal/ceres/" + filename for filename in [
     "sparse_cholesky.cc",
     "sparse_matrix.cc",
     "sparse_normal_cholesky_solver.cc",
-    "split.cc",
     "stringprintf.cc",
     "subset_preconditioner.cc",
     "suitesparse.cc",


### PR DESCRIPTION
"split.cc" is already deleted in https://github.com/ceres-solver/ceres-solver/commit/06e02a17359079c23e95b6d5b521e062391f8f0a#diff-b2d1fe48671a8faf7e7b220254b0aae0a3ba1239166eeccb1d81c878f5189905. Having it in CERES_SRCS causes the build failure.
Also see https://github.com/google/mediapipe/blob/master/third_party/ceres_solver_compatibility_fixes.diff#L23.