### PR TITLE
Adds missing functional include in thread_pool.h

### DIFF
--- a/internal/ceres/thread_pool.h
+++ b/internal/ceres/thread_pool.h
@@ -31,6 +31,7 @@
 #ifndef CERES_INTERNAL_THREAD_POOL_H_
 #define CERES_INTERNAL_THREAD_POOL_H_
 
+#include <functional>
 #include <mutex>
 #include <thread>
 #include <vector>


### PR DESCRIPTION
Fixes a build error when building with CXX11_THREADS=ON.

Change-Id: I5828dc408261c88a93745c2ade0b8da740a68e54