### PR TITLE
link static cuda libs when ceres is build static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,11 +231,16 @@ if (USE_CUDA)
         set(CMAKE_CUDA_ARCHITECTURES "50;60;70;80")
         message("-- Setting CUDA Architecture to ${CMAKE_CUDA_ARCHITECTURES}")
       endif()
+
+      if(UNIX AND NOT BUILD_SHARED_LIBS)
+        set(CUDA_LIB_EXT "_static")
+      endif()
+
       list(APPEND CERES_CUDA_LIBRARIES
-        CUDA::cublas
-        CUDA::cudart
-        CUDA::cusolver
-        CUDA::cusparse)
+        CUDA::cublas${CUDA_LIB_EXT}
+        CUDA::cudart${CUDA_LIB_EXT}
+        CUDA::cusolver${CUDA_LIB_EXT}
+        CUDA::cusparse${CUDA_LIB_EXT})
       set(CMAKE_CUDA_RUNTIME_LIBRARY NONE)
     else (CUDAToolkit_FOUND)
       message("-- Did not find CUDA, disabling CUDA support.")

--- a/internal/ceres/CMakeLists.txt
+++ b/internal/ceres/CMakeLists.txt
@@ -120,10 +120,10 @@ endif()
 
 if (USE_CUDA)
   list(APPEND CERES_LIBRARY_PRIVATE_DEPENDENCIES
-    CUDA::cublas
-    CUDA::cudart
-    CUDA::cusolver
-    CUDA::cusparse)
+    CUDA::cublas${CUDA_LIB_EXT}
+    CUDA::cudart${CUDA_LIB_EXT}
+    CUDA::cusolver${CUDA_LIB_EXT}
+    CUDA::cusparse${CUDA_LIB_EXT})
   set_source_files_properties(cuda_kernels_vector_ops.cu.cc PROPERTIES LANGUAGE CUDA)
   set_source_files_properties(cuda_kernels_bsm_to_crs.cu.cc PROPERTIES LANGUAGE CUDA)
   add_library(ceres_cuda_kernels STATIC cuda_kernels_vector_ops.cu.cc cuda_kernels_bsm_to_crs.cu.cc)


### PR DESCRIPTION
In recent CMake versions there are special targets with `_static` postfix for linking CUDA libraries statically. This PR makes usage of them when ceres itself is build as static library. This is the same mechanism as it is used in OpenCV.