### PR TITLE
Fix Spawning Threads inside ceres::Covariance when num_threads=1

### DIFF
--- a/internal/ceres/covariance_impl.cc
+++ b/internal/ceres/covariance_impl.cc
@@ -319,7 +319,7 @@ bool CovarianceImpl::GetCovarianceMatrixInTangentOrAmbientSpace(
   // Technically the following code is a double nested loop where
   // i = 1:n, j = i:n.
   int iteration_count = (num_parameters * (num_parameters + 1)) / 2;
-  problem_->context()->EnsureMinimumThreads(num_threads);
+  problem_->context()->EnsureMinimumThreads(num_threads - 1);
   ParallelFor(problem_->context(),
               0,
               iteration_count,
@@ -668,7 +668,7 @@ bool CovarianceImpl::ComputeCovarianceValuesUsingSuiteSparseQR() {
   const int num_threads = options_.num_threads;
   auto workspace = std::make_unique<double[]>(num_threads * num_cols);
 
-  problem_->context()->EnsureMinimumThreads(num_threads);
+  problem_->context()->EnsureMinimumThreads(num_threads - 1);
   ParallelFor(
       problem_->context(), 0, num_cols, num_threads, [&](int thread_id, int r) {
         const int row_begin = rows[r];
@@ -859,7 +859,7 @@ bool CovarianceImpl::ComputeCovarianceValuesUsingEigenSparseQR() {
   const int num_threads = options_.num_threads;
   auto workspace = std::make_unique<double[]>(num_threads * num_cols);
 
-  problem_->context()->EnsureMinimumThreads(num_threads);
+  problem_->context()->EnsureMinimumThreads(num_threads - 1);
   ParallelFor(
       problem_->context(), 0, num_cols, num_threads, [&](int thread_id, int r) {
         const int row_begin = rows[r];


### PR DESCRIPTION
This PR fixes a bug where Ceres would internally spawn a new thread every time a `ceres::Covariance` object was created even though `num_threads` was set to 1.
This had a negative performance impact where if we called `ceres::Covariance` inside a tight loop, we'd create many threads very quickly even though the code was supposed to be single-threaded.

After these changes, we now ensure we have at least `num_threads-1`. This is consistent with the rest of the code (e.g. `ceres::Solver`, `ceres::ProblemImpl`) and ensures that the covariance calculations stay single-threaded when `num_threads=1`.