### PR TITLE
CMake: Eigen 5.x compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ unset(CERES_COMPILE_OPTIONS)
 
 # Eigen.
 # Eigen delivers Eigen3Config.cmake since v3.3.3
-find_package(Eigen3 3.3.4 REQUIRED NO_MODULE)
+find_package(Eigen3 REQUIRED CONFIG)
 if (Eigen3_FOUND)
   message("-- Found Eigen version ${Eigen3_VERSION}: ${Eigen3_DIR}")
   if (EIGENSPARSE)


### PR DESCRIPTION
Change-Id: Id018655d2295cd2828948aa550683423a3cad893

With 5.0 we get:

```
  The following configuration files were considered but not accepted:

    /usr/local/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0
```
so its easier to drop the version; 3.3 is super old anyway