### PR TITLE
Fix typo in nnls_modeling.rst regarding Triggs correction (a > should be a < )

### DIFF
--- a/docs/source/nnls_modeling.rst
+++ b/docs/source/nnls_modeling.rst
@@ -1189,7 +1189,7 @@ problems.
 
 
 While the theory described above is elegant, in practice we observe
-that using the Triggs correction when :math:`\rho'' > 0` leads to poor
+that using the Triggs correction when :math:`\rho'' < 0` leads to poor
 performance, so we upper bound it by zero. For more details see
 `corrector.cc <https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/corrector.cc#L51>`_
 


### PR DESCRIPTION
According to both the comment in the code and the code itself it is for \rho'' < 0 a special case, the docs however stated > 0