### PR TITLE
Fix AngleManifold::Minus to normalize result

### DIFF
--- a/examples/slam/pose_graph_2d/angle_manifold.h
+++ b/examples/slam/pose_graph_2d/angle_manifold.h
@@ -53,7 +53,7 @@ class AngleManifold {
              const T* x_radians,
              T* y_minus_x_radians) const {
     *y_minus_x_radians =
-        NormalizeAngle(*y_radians) - NormalizeAngle(*x_radians);
+        NormalizeAngle(*y_radians - *x_radians);
 
     return true;
   }


### PR DESCRIPTION
The Minus operation should normalize the difference between two angles to ensure the result is in [-π, π) range. Previously, normalizing each angle separately before subtraction could result in an angle outside the valid range.

Fixes: Issue where angle differences outside [-π, π) could cause incorrect optimization step calculations.